### PR TITLE
Add WooCommerce sales integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ _If you are looking for a React admin dashboard starter, here is the [repo](http
 | [Signup / Signin](https://go.clerk.com/ILdYhn7)      | Authentication with **Clerk** provides secure authentication and user management with multiple sign-in options including passwordless authentication, social logins, and enterprise SSO - all designed to enhance security while delivering a seamless user experience. |
 | [Dashboard (Overview)](https://shadcn-dashboard.kiranism.dev/dashboard)    | Cards with Recharts graphs for analytics. Parallel routes in the overview sections feature independent loading, error handling, and isolated component rendering. |
 | [Product](https://shadcn-dashboard.kiranism.dev/dashboard/product)         | Tanstack tables with server side searching, filter, pagination by Nuqs which is a Type-safe search params state manager in nextjs                                                                                                                                       |
+| WooCommerce Sales | Displays recent orders from your WooCommerce store |
 | [Product/new](https://shadcn-dashboard.kiranism.dev/dashboard/product/new) | A Product Form with shadcn form (react-hook-form + zod).                                                                                                                                                                                                                |
 | [Profile](https://shadcn-dashboard.kiranism.dev/dashboard/profile)         | Clerk's full-featured account management UI that allows users to manage their profile and security settings                                                                                                                                                             |
 | [Kanban Board](https://shadcn-dashboard.kiranism.dev/dashboard/kanban)     | A Drag n Drop task management board with dnd-kit and zustand to persist state locally.                                                                                                                                                                                  |
@@ -105,7 +106,7 @@ git clone https://github.com/Kiranism/next-shadcn-dashboard-starter.git
 
 ##### Environment Configuration Setup
 
-To configure the environment for this project, refer to the `env.example.txt` file. This file contains the necessary environment variables required for authentication and error tracking.
+To configure the environment for this project, refer to the `env.example.txt` file. This file contains the necessary environment variables required for authentication, error tracking and connecting to WooCommerce.
 
 You should now be able to access the application at http://localhost:3000.
 

--- a/env.example.txt
+++ b/env.example.txt
@@ -57,6 +57,16 @@ NEXT_PUBLIC_SENTRY_DISABLED= "false"
 
 
 # =================================================================
+# WooCommerce API Configuration
+# =================================================================
+# Base URL of your WooCommerce store (e.g. https://example.com)
+WOOCOMMERCE_API_URL=
+# WooCommerce REST API keys
+WOOCOMMERCE_CONSUMER_KEY=
+WOOCOMMERCE_CONSUMER_SECRET=
+
+
+# =================================================================
 # Important Notes:
 # =================================================================
 # 1. Rename this file to '.env' for local development

--- a/src/app/dashboard/woo-sales/page.tsx
+++ b/src/app/dashboard/woo-sales/page.tsx
@@ -1,0 +1,23 @@
+import PageContainer from '@/components/layout/page-container';
+import { Heading } from '@/components/ui/heading';
+import OrderList from '@/features/woocommerce/components/order-list';
+import { getWooOrders } from '@/features/woocommerce/actions/get-orders';
+
+export const metadata = {
+  title: 'Dashboard: WooCommerce Sales'
+};
+
+export default async function WooSalesPage() {
+  const orders = await getWooOrders();
+  return (
+    <PageContainer>
+      <div className='flex flex-1 flex-col space-y-4'>
+        <Heading
+          title='WooCommerce Sales'
+          description='Latest orders from your WooCommerce store'
+        />
+        <OrderList orders={orders} />
+      </div>
+    </PageContainer>
+  );
+}

--- a/src/constants/data.ts
+++ b/src/constants/data.ts
@@ -30,6 +30,14 @@ export const navItems: NavItem[] = [
     items: [] // No child items
   },
   {
+    title: 'Woo Sales',
+    url: '/dashboard/woo-sales',
+    icon: 'billing',
+    shortcut: ['w', 'w'],
+    isActive: false,
+    items: [] // No child items
+  },
+  {
     title: 'Account',
     url: '#', // Placeholder as there is no direct link for the parent
     icon: 'billing',

--- a/src/features/woocommerce/actions/get-orders.ts
+++ b/src/features/woocommerce/actions/get-orders.ts
@@ -1,0 +1,38 @@
+export interface WooOrder {
+  id: number;
+  billing: {
+    first_name: string;
+    last_name: string;
+    email: string;
+  };
+  total: string;
+}
+
+export async function getWooOrders(): Promise<WooOrder[]> {
+  const base = process.env.WOOCOMMERCE_API_URL;
+  const key = process.env.WOOCOMMERCE_CONSUMER_KEY;
+  const secret = process.env.WOOCOMMERCE_CONSUMER_SECRET;
+
+  if (!base || !key || !secret) {
+    console.error('Missing WooCommerce environment variables');
+    return [];
+  }
+
+  const auth = Buffer.from(`${key}:${secret}`).toString('base64');
+  const res = await fetch(
+    `${base.replace(/\/$/, '')}/wp-json/wc/v3/orders?per_page=5&orderby=date&order=desc`,
+    {
+      headers: {
+        Authorization: `Basic ${auth}`,
+        'Content-Type': 'application/json'
+      }
+    }
+  );
+
+  if (!res.ok) {
+    console.error('Failed to fetch orders from WooCommerce', await res.text());
+    return [];
+  }
+
+  return res.json();
+}

--- a/src/features/woocommerce/components/order-list.tsx
+++ b/src/features/woocommerce/components/order-list.tsx
@@ -1,0 +1,52 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  CardTitle,
+  CardDescription
+} from '@/components/ui/card';
+import type { WooOrder } from '../actions/get-orders';
+
+function initials(first: string, last: string) {
+  return `${first.charAt(0)}${last.charAt(0)}`.toUpperCase();
+}
+
+export default function OrderList({ orders }: { orders: WooOrder[] }) {
+  return (
+    <Card className='h-full'>
+      <CardHeader>
+        <CardTitle>Recent WooCommerce Sales</CardTitle>
+        <CardDescription>
+          You have {orders.length} recent orders.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className='space-y-8'>
+          {orders.map((order) => (
+            <div key={order.id} className='flex items-center'>
+              <Avatar className='h-9 w-9'>
+                <AvatarImage
+                  src={`https://avatars.dicebear.com/api/initials/${order.billing.first_name}%20${order.billing.last_name}.svg`}
+                  alt='Avatar'
+                />
+                <AvatarFallback>
+                  {initials(order.billing.first_name, order.billing.last_name)}
+                </AvatarFallback>
+              </Avatar>
+              <div className='ml-4 space-y-1'>
+                <p className='text-sm leading-none font-medium'>
+                  {order.billing.first_name} {order.billing.last_name}
+                </p>
+                <p className='text-muted-foreground text-sm'>
+                  {order.billing.email}
+                </p>
+              </div>
+              <div className='ml-auto font-medium'>${order.total}</div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add WooCommerce API variables in `.env.example`
- add sidebar item for WooCommerce sales
- show latest WooCommerce orders in `/dashboard/woo-sales`
- describe WooCommerce page and env vars in docs

## Testing
- `pnpm install`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6844ec9dce28832bbbd0f5d393a19add