### PR TITLE
Integrate MercadoLibre sales data

### DIFF
--- a/env.example.txt
+++ b/env.example.txt
@@ -63,3 +63,11 @@ NEXT_PUBLIC_SENTRY_DISABLED= "false"
 # 2. Never commit the actual '.env' file to version control
 # 3. Make sure to replace all placeholder values with real ones
 # 4. Keep your secret keys private and never share them
+
+# ================================================================
+# MercadoLibre API Configuration
+# ================================================================
+# Access token for MercadoLibre API
+MERCADOLIBRE_ACCESS_TOKEN=
+# Seller ID associated with your MercadoLibre account
+MERCADOLIBRE_SELLER_ID=

--- a/src/app/dashboard/overview/@sales/page.tsx
+++ b/src/app/dashboard/overview/@sales/page.tsx
@@ -1,7 +1,17 @@
 import { delay } from '@/constants/mock-api';
-import { RecentSales } from '@/features/overview/components/recent-sales';
+import {
+  RecentSales,
+  type RecentSale
+} from '@/features/overview/components/recent-sales';
+import { fetchOrders } from '@/lib/mercadolibre';
 
 export default async function Sales() {
   await delay(3000);
-  return <RecentSales />;
+  const orders = await fetchOrders();
+  const sales: RecentSale[] = orders.map((o) => ({
+    name: o.buyer.nickname,
+    fallback: o.buyer.nickname.slice(0, 2).toUpperCase(),
+    amount: `+$${o.total_amount}`
+  }));
+  return <RecentSales sales={sales} />;
 }

--- a/src/features/overview/components/overview.tsx
+++ b/src/features/overview/components/overview.tsx
@@ -12,11 +12,18 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { AreaGraph } from './area-graph';
 import { BarGraph } from './bar-graph';
 import { PieGraph } from './pie-graph';
-import { RecentSales } from './recent-sales';
+import { RecentSales, type RecentSale } from './recent-sales';
+import { fetchOrders } from '@/lib/mercadolibre';
 import { IconTrendingUp, IconTrendingDown } from '@tabler/icons-react';
 import { Badge } from '@/components/ui/badge';
 
-export default function OverViewPage() {
+export default async function OverViewPage() {
+  const orders = await fetchOrders();
+  const sales: RecentSale[] = orders.map((o) => ({
+    name: o.buyer.nickname,
+    fallback: o.buyer.nickname.slice(0, 2).toUpperCase(),
+    amount: `+$${o.total_amount}`
+  }));
   return (
     <PageContainer>
       <div className='flex flex-1 flex-col space-y-2'>
@@ -132,7 +139,7 @@ export default function OverViewPage() {
                 <BarGraph />
               </div>
               <Card className='col-span-4 md:col-span-3'>
-                <RecentSales />
+                <RecentSales sales={sales} />
               </Card>
               <div className='col-span-4'>
                 <AreaGraph />

--- a/src/features/overview/components/recent-sales.tsx
+++ b/src/features/overview/components/recent-sales.tsx
@@ -7,62 +7,38 @@ import {
   CardDescription
 } from '@/components/ui/card';
 
-const salesData = [
-  {
-    name: 'Olivia Martin',
-    email: 'olivia.martin@email.com',
-    avatar: 'https://api.slingacademy.com/public/sample-users/1.png',
-    fallback: 'OM',
-    amount: '+$1,999.00'
-  },
-  {
-    name: 'Jackson Lee',
-    email: 'jackson.lee@email.com',
-    avatar: 'https://api.slingacademy.com/public/sample-users/2.png',
-    fallback: 'JL',
-    amount: '+$39.00'
-  },
-  {
-    name: 'Isabella Nguyen',
-    email: 'isabella.nguyen@email.com',
-    avatar: 'https://api.slingacademy.com/public/sample-users/3.png',
-    fallback: 'IN',
-    amount: '+$299.00'
-  },
-  {
-    name: 'William Kim',
-    email: 'will@email.com',
-    avatar: 'https://api.slingacademy.com/public/sample-users/4.png',
-    fallback: 'WK',
-    amount: '+$99.00'
-  },
-  {
-    name: 'Sofia Davis',
-    email: 'sofia.davis@email.com',
-    avatar: 'https://api.slingacademy.com/public/sample-users/5.png',
-    fallback: 'SD',
-    amount: '+$39.00'
-  }
-];
+export interface RecentSale {
+  name: string;
+  email?: string;
+  avatar?: string;
+  fallback: string;
+  amount: string;
+}
 
-export function RecentSales() {
+export function RecentSales({ sales }: { sales: RecentSale[] }) {
   return (
     <Card className='h-full'>
       <CardHeader>
         <CardTitle>Recent Sales</CardTitle>
-        <CardDescription>You made 265 sales this month.</CardDescription>
+        <CardDescription>
+          You made {sales.length} sales this month.
+        </CardDescription>
       </CardHeader>
       <CardContent>
         <div className='space-y-8'>
-          {salesData.map((sale, index) => (
+          {sales.map((sale, index) => (
             <div key={index} className='flex items-center'>
               <Avatar className='h-9 w-9'>
-                <AvatarImage src={sale.avatar} alt='Avatar' />
+                {sale.avatar ? (
+                  <AvatarImage src={sale.avatar} alt='Avatar' />
+                ) : null}
                 <AvatarFallback>{sale.fallback}</AvatarFallback>
               </Avatar>
               <div className='ml-4 space-y-1'>
                 <p className='text-sm leading-none font-medium'>{sale.name}</p>
-                <p className='text-muted-foreground text-sm'>{sale.email}</p>
+                {sale.email && (
+                  <p className='text-muted-foreground text-sm'>{sale.email}</p>
+                )}
               </div>
               <div className='ml-auto font-medium'>{sale.amount}</div>
             </div>

--- a/src/lib/mercadolibre.ts
+++ b/src/lib/mercadolibre.ts
@@ -1,0 +1,28 @@
+export interface MercadoLibreOrder {
+  id: number;
+  date_created: string;
+  total_amount: number;
+  buyer: {
+    nickname: string;
+  };
+}
+
+export async function fetchOrders(): Promise<MercadoLibreOrder[]> {
+  const token = process.env.MERCADOLIBRE_ACCESS_TOKEN;
+  const sellerId = process.env.MERCADOLIBRE_SELLER_ID;
+  if (!token || !sellerId) {
+    console.warn('MercadoLibre credentials not provided');
+    return [];
+  }
+
+  const url = `https://api.mercadolibre.com/orders/search?seller=${sellerId}&access_token=${token}`;
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    console.error('Failed to fetch MercadoLibre orders', await res.text());
+    return [];
+  }
+
+  const data = await res.json();
+  return data.results as MercadoLibreOrder[];
+}


### PR DESCRIPTION
## Summary
- add MercadoLibre API env variables
- create helper to fetch MercadoLibre orders
- pull sales data from MercadoLibre in overview and sales pages
- pass sales data to `RecentSales` component

## Testing
- `npm run lint`
- `npm run build` *(fails: Next.js build was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6844ec746690832b94e25344396af3d5