### PR TITLE
Implement MercadoLibre message replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ _If you are looking for a React admin dashboard starter, here is the [repo](http
 | [Product/new](https://shadcn-dashboard.kiranism.dev/dashboard/product/new) | A Product Form with shadcn form (react-hook-form + zod).                                                                                                                                                                                                                |
 | [Profile](https://shadcn-dashboard.kiranism.dev/dashboard/profile)         | Clerk's full-featured account management UI that allows users to manage their profile and security settings                                                                                                                                                             |
 | [Kanban Board](https://shadcn-dashboard.kiranism.dev/dashboard/kanban)     | A Drag n Drop task management board with dnd-kit and zustand to persist state locally.                                                                                                                                                                                  |
+| [MercadoLibre Messages](https://shadcn-dashboard.kiranism.dev/dashboard/mercadolibre/messages) | Lists conversation messages retrieved from the MercadoLibre API and allows replying.
+| [MercadoLibre Questions](https://shadcn-dashboard.kiranism.dev/dashboard/mercadolibre/questions) | Displays product questions received via MercadoLibre.
 | [Not Found](https://shadcn-dashboard.kiranism.dev/dashboard/notfound)      | Not Found Page Added in the root level                                                                                                                                                                                                                                  |
 | [Global Error](https://sentry.io/for/nextjs/?utm_source=github&utm_medium=paid-community&utm_campaign=general-fy26q2-nextjs&utm_content=github-banner-project-tryfree)           | A centralized error page that captures and displays errors across the application. Integrated with **Sentry** to log errors, provide detailed reports, and enable replay functionality for better debugging. |
 
@@ -101,6 +103,8 @@ git clone https://github.com/Kiranism/next-shadcn-dashboard-starter.git
 - Create a `.env.local` file by copying the example environment file:
   `cp env.example.txt .env.local`
 - Add the required environment variables to the `.env.local` file.
+- Include your MercadoLibre credentials in `.env.local`:
+  `MERCADOLIBRE_ACCESS_TOKEN` and `MERCADOLIBRE_USER_ID`.
 - `pnpm run dev`
 
 ##### Environment Configuration Setup

--- a/env.example.txt
+++ b/env.example.txt
@@ -55,6 +55,15 @@ SENTRY_AUTH_TOKEN=    #Example: sntrys_************************************
 
 NEXT_PUBLIC_SENTRY_DISABLED= "false"
 
+# -----------------------------------------------------------------
+# MercadoLibre API Configuration
+# -----------------------------------------------------------------
+# Access token for MercadoLibre API requests
+MERCADOLIBRE_ACCESS_TOKEN=
+
+# Seller ID for your MercadoLibre account
+MERCADOLIBRE_USER_ID=
+
 
 # =================================================================
 # Important Notes:

--- a/src/app/api/mercadolibre/send-message/route.ts
+++ b/src/app/api/mercadolibre/send-message/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const token = process.env.MERCADOLIBRE_ACCESS_TOKEN;
+  const seller = process.env.MERCADOLIBRE_USER_ID;
+
+  if (!token || !seller) {
+    return NextResponse.json(
+      { error: 'MercadoLibre credentials are not configured.' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const { packId, text } = await req.json();
+
+    const res = await fetch(
+      `https://api.mercadolibre.com/messages/packs/${packId}/sellers/${seller}/messages`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ text })
+      }
+    );
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      return NextResponse.json(data, { status: res.status });
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Failed to send message' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/mercadolibre/messages/page.tsx
+++ b/src/app/dashboard/mercadolibre/messages/page.tsx
@@ -1,0 +1,26 @@
+import PageContainer from '@/components/layout/page-container';
+import { getMercadoLibreMessages } from '@/features/mercadolibre/utils/messages';
+import MessageReplyForm from '@/features/mercadolibre/components/message-reply-form';
+
+export const metadata = {
+  title: 'Dashboard: MercadoLibre Messages'
+};
+
+export default async function Page() {
+  const data = await getMercadoLibreMessages();
+
+  if (!data) {
+    return <PageContainer>Failed to load MercadoLibre messages.</PageContainer>;
+  }
+
+  return (
+    <PageContainer>
+      <div className='flex flex-col gap-4'>
+        <pre className='whitespace-pre-wrap'>
+          {JSON.stringify(data, null, 2)}
+        </pre>
+        <MessageReplyForm />
+      </div>
+    </PageContainer>
+  );
+}

--- a/src/app/dashboard/mercadolibre/questions/page.tsx
+++ b/src/app/dashboard/mercadolibre/questions/page.tsx
@@ -1,0 +1,22 @@
+import PageContainer from '@/components/layout/page-container';
+import { getMercadoLibreQuestions } from '@/features/mercadolibre/utils/questions';
+
+export const metadata = {
+  title: 'Dashboard: MercadoLibre Questions'
+};
+
+export default async function Page() {
+  const data = await getMercadoLibreQuestions();
+
+  if (!data) {
+    return (
+      <PageContainer>Failed to load MercadoLibre questions.</PageContainer>
+    );
+  }
+
+  return (
+    <PageContainer>
+      <pre className='whitespace-pre-wrap'>{JSON.stringify(data, null, 2)}</pre>
+    </PageContainer>
+  );
+}

--- a/src/constants/data.ts
+++ b/src/constants/data.ts
@@ -57,6 +57,27 @@ export const navItems: NavItem[] = [
     shortcut: ['k', 'k'],
     isActive: false,
     items: [] // No child items
+  },
+  {
+    title: 'MercadoLibre',
+    url: '#',
+    icon: 'billing',
+    shortcut: ['m', 'l'],
+    isActive: false,
+    items: [
+      {
+        title: 'Messages',
+        url: '/dashboard/mercadolibre/messages',
+        icon: 'post',
+        shortcut: ['m', 'm']
+      },
+      {
+        title: 'Questions',
+        url: '/dashboard/mercadolibre/questions',
+        icon: 'help',
+        shortcut: ['m', 'q']
+      }
+    ]
   }
 ];
 

--- a/src/features/mercadolibre/components/message-reply-form.tsx
+++ b/src/features/mercadolibre/components/message-reply-form.tsx
@@ -1,0 +1,59 @@
+'use client';
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+
+export default function MessageReplyForm() {
+  const [packId, setPackId] = useState('');
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setLoading(true);
+    setStatus(null);
+    try {
+      const res = await fetch('/api/mercadolibre/send-message', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ packId, text: message })
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setStatus(data.error || 'Failed to send message');
+      } else {
+        setStatus('Message sent successfully');
+        setMessage('');
+      }
+    } catch (err) {
+      setStatus('Failed to send message');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className='max-w-sm space-y-2'>
+      <Input
+        placeholder='Pack ID'
+        value={packId}
+        onChange={(e) => setPackId(e.target.value)}
+        required
+      />
+      <Textarea
+        placeholder='Your message...'
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        required
+      />
+      <Button type='submit' disabled={loading} size='sm'>
+        Send Message
+      </Button>
+      {status && <p className='text-sm'>{status}</p>}
+    </form>
+  );
+}

--- a/src/features/mercadolibre/utils/messages.ts
+++ b/src/features/mercadolibre/utils/messages.ts
@@ -1,0 +1,52 @@
+export async function getMercadoLibreMessages() {
+  const token = process.env.MERCADOLIBRE_ACCESS_TOKEN;
+  const seller = process.env.MERCADOLIBRE_USER_ID;
+
+  if (!token || !seller) {
+    return null;
+  }
+
+  const res = await fetch(
+    `https://api.mercadolibre.com/messages/packs?seller=${seller}&limit=10`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    }
+  );
+
+  if (!res.ok) {
+    return null;
+  }
+
+  const data = await res.json();
+  return data;
+}
+
+export async function sendMercadoLibreMessage(packId: string, text: string) {
+  const token = process.env.MERCADOLIBRE_ACCESS_TOKEN;
+  const seller = process.env.MERCADOLIBRE_USER_ID;
+
+  if (!token || !seller) {
+    return null;
+  }
+
+  const res = await fetch(
+    `https://api.mercadolibre.com/messages/packs/${packId}/sellers/${seller}/messages`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ text })
+    }
+  );
+
+  if (!res.ok) {
+    return null;
+  }
+
+  const data = await res.json();
+  return data;
+}

--- a/src/features/mercadolibre/utils/questions.ts
+++ b/src/features/mercadolibre/utils/questions.ts
@@ -1,0 +1,24 @@
+export async function getMercadoLibreQuestions() {
+  const token = process.env.MERCADOLIBRE_ACCESS_TOKEN;
+  const seller = process.env.MERCADOLIBRE_USER_ID;
+
+  if (!token || !seller) {
+    return null;
+  }
+
+  const res = await fetch(
+    `https://api.mercadolibre.com/questions/search?seller_id=${seller}&limit=10`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    }
+  );
+
+  if (!res.ok) {
+    return null;
+  }
+
+  const data = await res.json();
+  return data;
+}


### PR DESCRIPTION
## Summary
- add a form for replying to MercadoLibre messages
- create API route `POST /api/mercadolibre/send-message` to forward replies
- expose `sendMercadoLibreMessage` utility
- update README entry for messages page

## Testing
- `npm run lint`
- `npm run test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844ecbe224c832b8b269967f6178161