### PR TITLE
Add WooCommerce order email notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is a starter template using the following stack:
 - Language - [TypeScript](https://www.typescriptlang.org)
 - Auth - [Clerk](https://go.clerk.com/ILdYhn7)
 - Error tracking - [<picture><img alt="Sentry" src="public/assets/sentry.svg">
-        </picture>](https://sentry.io/for/nextjs/?utm_source=github&utm_medium=paid-community&utm_campaign=general-fy26q2-nextjs&utm_content=github-banner-project-tryfree)
+  </picture>](https://sentry.io/for/nextjs/?utm_source=github&utm_medium=paid-community&utm_campaign=general-fy26q2-nextjs&utm_content=github-banner-project-tryfree)
 - Styling - [Tailwind CSS v4](https://tailwindcss.com)
 - Components - [Shadcn-ui](https://ui.shadcn.com)
 - Schema Validations - [Zod](https://zod.dev)
@@ -36,16 +36,17 @@ _If you are looking for a React admin dashboard starter, here is the [repo](http
 
 ## Pages
 
-| Pages                                                                                 | Specifications                                                                                                                                                                                                                                                          |
-| :------------------------------------------------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Signup / Signin](https://go.clerk.com/ILdYhn7)      | Authentication with **Clerk** provides secure authentication and user management with multiple sign-in options including passwordless authentication, social logins, and enterprise SSO - all designed to enhance security while delivering a seamless user experience. |
-| [Dashboard (Overview)](https://shadcn-dashboard.kiranism.dev/dashboard)    | Cards with Recharts graphs for analytics. Parallel routes in the overview sections feature independent loading, error handling, and isolated component rendering. |
-| [Product](https://shadcn-dashboard.kiranism.dev/dashboard/product)         | Tanstack tables with server side searching, filter, pagination by Nuqs which is a Type-safe search params state manager in nextjs                                                                                                                                       |
-| [Product/new](https://shadcn-dashboard.kiranism.dev/dashboard/product/new) | A Product Form with shadcn form (react-hook-form + zod).                                                                                                                                                                                                                |
-| [Profile](https://shadcn-dashboard.kiranism.dev/dashboard/profile)         | Clerk's full-featured account management UI that allows users to manage their profile and security settings                                                                                                                                                             |
-| [Kanban Board](https://shadcn-dashboard.kiranism.dev/dashboard/kanban)     | A Drag n Drop task management board with dnd-kit and zustand to persist state locally.                                                                                                                                                                                  |
-| [Not Found](https://shadcn-dashboard.kiranism.dev/dashboard/notfound)      | Not Found Page Added in the root level                                                                                                                                                                                                                                  |
-| [Global Error](https://sentry.io/for/nextjs/?utm_source=github&utm_medium=paid-community&utm_campaign=general-fy26q2-nextjs&utm_content=github-banner-project-tryfree)           | A centralized error page that captures and displays errors across the application. Integrated with **Sentry** to log errors, provide detailed reports, and enable replay functionality for better debugging. |
+| Pages                                                                                                                                                                  | Specifications                                                                                                                                                                                                                                                          |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Signup / Signin](https://go.clerk.com/ILdYhn7)                                                                                                                        | Authentication with **Clerk** provides secure authentication and user management with multiple sign-in options including passwordless authentication, social logins, and enterprise SSO - all designed to enhance security while delivering a seamless user experience. |
+| [Dashboard (Overview)](https://shadcn-dashboard.kiranism.dev/dashboard)                                                                                                | Cards with Recharts graphs for analytics. Parallel routes in the overview sections feature independent loading, error handling, and isolated component rendering.                                                                                                       |
+| [Product](https://shadcn-dashboard.kiranism.dev/dashboard/product)                                                                                                     | Tanstack tables with server side searching, filter, pagination by Nuqs which is a Type-safe search params state manager in nextjs                                                                                                                                       |
+| WooCommerce Sales                                                                                                                                                      | Displays recent orders from your WooCommerce store and automatically emails customers when they make a purchase                                                                                                                                                         |
+| [Product/new](https://shadcn-dashboard.kiranism.dev/dashboard/product/new)                                                                                             | A Product Form with shadcn form (react-hook-form + zod).                                                                                                                                                                                                                |
+| [Profile](https://shadcn-dashboard.kiranism.dev/dashboard/profile)                                                                                                     | Clerk's full-featured account management UI that allows users to manage their profile and security settings                                                                                                                                                             |
+| [Kanban Board](https://shadcn-dashboard.kiranism.dev/dashboard/kanban)                                                                                                 | A Drag n Drop task management board with dnd-kit and zustand to persist state locally.                                                                                                                                                                                  |
+| [Not Found](https://shadcn-dashboard.kiranism.dev/dashboard/notfound)                                                                                                  | Not Found Page Added in the root level                                                                                                                                                                                                                                  |
+| [Global Error](https://sentry.io/for/nextjs/?utm_source=github&utm_medium=paid-community&utm_campaign=general-fy26q2-nextjs&utm_content=github-banner-project-tryfree) | A centralized error page that captures and displays errors across the application. Integrated with **Sentry** to log errors, provide detailed reports, and enable replay functionality for better debugging.                                                            |
 
 ## Feature based organization
 
@@ -105,9 +106,12 @@ git clone https://github.com/Kiranism/next-shadcn-dashboard-starter.git
 
 ##### Environment Configuration Setup
 
-To configure the environment for this project, refer to the `env.example.txt` file. This file contains the necessary environment variables required for authentication and error tracking.
+To configure the environment for this project, refer to the `env.example.txt` file. This file contains the necessary environment variables required for authentication, error tracking, connecting to WooCommerce, and sending order notification emails.
 
 You should now be able to access the application at http://localhost:3000.
+
+To enable automatic order notifications, configure a WooCommerce webhook to send
+`order.created` events to `/api/woocommerce/webhook` on your deployment.
 
 > [!WARNING]
 > After cloning or forking the repository, be cautious when pulling or syncing with the latest changes, as this may result in breaking conflicts.

--- a/env.example.txt
+++ b/env.example.txt
@@ -57,6 +57,30 @@ NEXT_PUBLIC_SENTRY_DISABLED= "false"
 
 
 # =================================================================
+# WooCommerce API Configuration
+# =================================================================
+# Base URL of your WooCommerce store (e.g. https://example.com)
+WOOCOMMERCE_API_URL=
+# WooCommerce REST API keys
+WOOCOMMERCE_CONSUMER_KEY=
+WOOCOMMERCE_CONSUMER_SECRET=
+
+# -----------------------------------------------------------------
+# Outbound Email Configuration for order notifications
+# -----------------------------------------------------------------
+# SMTP server host
+SMTP_HOST=
+# SMTP server port
+SMTP_PORT=
+# Authentication username
+SMTP_USER=
+# Authentication password
+SMTP_PASS=
+# Email address used as the sender
+SMTP_FROM=
+
+
+# =================================================================
 # Important Notes:
 # =================================================================
 # 1. Rename this file to '.env' for local development

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "next": "15.3.2",
     "next-themes": "^0.4.6",
     "nextjs-toploader": "^3.7.15",
+    "nodemailer": "^7.0.3",
     "nuqs": "^2.4.1",
     "postcss": "8.4.49",
     "react": "19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       nextjs-toploader:
         specifier: ^3.7.15
         version: 3.8.16(next@15.3.2(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      nodemailer:
+        specifier: ^7.0.3
+        version: 7.0.3
       nuqs:
         specifier: ^2.4.1
         version: 2.4.1(next@15.3.2(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
@@ -3571,6 +3574,10 @@ packages:
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
+  nodemailer@7.0.3:
+    resolution: {integrity: sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw==}
+    engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -8078,6 +8085,8 @@ snapshots:
       whatwg-url: 5.0.0
 
   node-releases@2.0.19: {}
+
+  nodemailer@7.0.3: {}
 
   normalize-path@3.0.0: {}
 

--- a/src/app/api/woocommerce/webhook/route.ts
+++ b/src/app/api/woocommerce/webhook/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import type { WooOrder } from '@/features/woocommerce/actions/get-orders';
+import { sendOrderEmail } from '@/features/woocommerce/actions/send-email';
+
+export async function POST(req: Request) {
+  const order = (await req.json()) as WooOrder;
+  try {
+    await sendOrderEmail(order);
+  } catch (err) {
+    console.error('Failed to send order email', err);
+  }
+  return NextResponse.json({ received: true });
+}

--- a/src/app/dashboard/woo-sales/page.tsx
+++ b/src/app/dashboard/woo-sales/page.tsx
@@ -1,0 +1,23 @@
+import PageContainer from '@/components/layout/page-container';
+import { Heading } from '@/components/ui/heading';
+import OrderList from '@/features/woocommerce/components/order-list';
+import { getWooOrders } from '@/features/woocommerce/actions/get-orders';
+
+export const metadata = {
+  title: 'Dashboard: WooCommerce Sales'
+};
+
+export default async function WooSalesPage() {
+  const orders = await getWooOrders();
+  return (
+    <PageContainer>
+      <div className='flex flex-1 flex-col space-y-4'>
+        <Heading
+          title='WooCommerce Sales'
+          description='Latest orders from your WooCommerce store'
+        />
+        <OrderList orders={orders} />
+      </div>
+    </PageContainer>
+  );
+}

--- a/src/constants/data.ts
+++ b/src/constants/data.ts
@@ -30,6 +30,14 @@ export const navItems: NavItem[] = [
     items: [] // No child items
   },
   {
+    title: 'Woo Sales',
+    url: '/dashboard/woo-sales',
+    icon: 'billing',
+    shortcut: ['w', 'w'],
+    isActive: false,
+    items: [] // No child items
+  },
+  {
     title: 'Account',
     url: '#', // Placeholder as there is no direct link for the parent
     icon: 'billing',

--- a/src/features/woocommerce/actions/get-orders.ts
+++ b/src/features/woocommerce/actions/get-orders.ts
@@ -1,0 +1,38 @@
+export interface WooOrder {
+  id: number;
+  billing: {
+    first_name: string;
+    last_name: string;
+    email: string;
+  };
+  total: string;
+}
+
+export async function getWooOrders(): Promise<WooOrder[]> {
+  const base = process.env.WOOCOMMERCE_API_URL;
+  const key = process.env.WOOCOMMERCE_CONSUMER_KEY;
+  const secret = process.env.WOOCOMMERCE_CONSUMER_SECRET;
+
+  if (!base || !key || !secret) {
+    console.error('Missing WooCommerce environment variables');
+    return [];
+  }
+
+  const auth = Buffer.from(`${key}:${secret}`).toString('base64');
+  const res = await fetch(
+    `${base.replace(/\/$/, '')}/wp-json/wc/v3/orders?per_page=5&orderby=date&order=desc`,
+    {
+      headers: {
+        Authorization: `Basic ${auth}`,
+        'Content-Type': 'application/json'
+      }
+    }
+  );
+
+  if (!res.ok) {
+    console.error('Failed to fetch orders from WooCommerce', await res.text());
+    return [];
+  }
+
+  return res.json();
+}

--- a/src/features/woocommerce/actions/send-email.ts
+++ b/src/features/woocommerce/actions/send-email.ts
@@ -1,0 +1,32 @@
+import nodemailer from 'nodemailer';
+import type { WooOrder } from './get-orders';
+
+export async function sendOrderEmail(order: WooOrder) {
+  const host = process.env.SMTP_HOST;
+  const port = process.env.SMTP_PORT;
+  const user = process.env.SMTP_USER;
+  const pass = process.env.SMTP_PASS;
+  const from = process.env.SMTP_FROM;
+
+  if (!host || !port || !user || !pass || !from) {
+    console.error('Missing SMTP environment variables');
+    return;
+  }
+
+  const transporter = nodemailer.createTransport({
+    host,
+    port: Number(port),
+    secure: Number(port) === 465,
+    auth: {
+      user,
+      pass
+    }
+  });
+
+  await transporter.sendMail({
+    from,
+    to: order.billing.email,
+    subject: 'Thank you for your purchase!',
+    text: `Hi ${order.billing.first_name}, thanks for your order (#${order.id}).`
+  });
+}

--- a/src/features/woocommerce/components/order-list.tsx
+++ b/src/features/woocommerce/components/order-list.tsx
@@ -1,0 +1,52 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  CardTitle,
+  CardDescription
+} from '@/components/ui/card';
+import type { WooOrder } from '../actions/get-orders';
+
+function initials(first: string, last: string) {
+  return `${first.charAt(0)}${last.charAt(0)}`.toUpperCase();
+}
+
+export default function OrderList({ orders }: { orders: WooOrder[] }) {
+  return (
+    <Card className='h-full'>
+      <CardHeader>
+        <CardTitle>Recent WooCommerce Sales</CardTitle>
+        <CardDescription>
+          You have {orders.length} recent orders.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className='space-y-8'>
+          {orders.map((order) => (
+            <div key={order.id} className='flex items-center'>
+              <Avatar className='h-9 w-9'>
+                <AvatarImage
+                  src={`https://avatars.dicebear.com/api/initials/${order.billing.first_name}%20${order.billing.last_name}.svg`}
+                  alt='Avatar'
+                />
+                <AvatarFallback>
+                  {initials(order.billing.first_name, order.billing.last_name)}
+                </AvatarFallback>
+              </Avatar>
+              <div className='ml-4 space-y-1'>
+                <p className='text-sm leading-none font-medium'>
+                  {order.billing.first_name} {order.billing.last_name}
+                </p>
+                <p className='text-muted-foreground text-sm'>
+                  {order.billing.email}
+                </p>
+              </div>
+              <div className='ml-auto font-medium'>${order.total}</div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate nodemailer to send order confirmation emails
- add API route to handle WooCommerce webhook events
- include SMTP env vars in example env file
- describe auto emails and webhook setup in the docs

## Testing
- `pnpm install`
- `pnpm lint` *(with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6844ec9dce28832bbbd0f5d393a19add