### PR TITLE
Add purchase message helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ To configure the environment for this project, refer to the `env.example.txt` fi
 
 You should now be able to access the application at http://localhost:3000.
 
+### Customizing the purchase message
+
+You can change the automatic thank you message sent to customers by using the
+helper functions exported from `src/lib/purchase-message.ts`:
+
+```ts
+import { setPurchaseMessage } from '@/lib/purchase-message';
+
+// Update the message that will be sent after a successful order
+setPurchaseMessage('Gracias por tu compra y por confiar en nosotros!');
+```
+
 > [!WARNING]
 > After cloning or forking the repository, be cautious when pulling or syncing with the latest changes, as this may result in breaking conflicts.
 

--- a/src/lib/purchase-message.ts
+++ b/src/lib/purchase-message.ts
@@ -1,0 +1,9 @@
+let purchaseMessage = 'Gracias por tu compra!';
+
+export function getPurchaseMessage(): string {
+  return purchaseMessage;
+}
+
+export function setPurchaseMessage(message: string): void {
+  purchaseMessage = message;
+}


### PR DESCRIPTION
## Summary
- add helper to manage purchase message
- document customizing purchase message

## Testing
- `pnpm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6844fd010f8c832bb1d0b120ec362754