### PR TITLE
Add server APIs for MercadoLibre data

### DIFF
--- a/src/app/api/mercadolibre/orders/route.ts
+++ b/src/app/api/mercadolibre/orders/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchOrders, fetchOrdersByDateRange } from '@/lib/mercadolibre';
+
+export async function GET(req: NextRequest) {
+  const searchParams = req.nextUrl.searchParams;
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+
+  try {
+    const orders =
+      from && to ? await fetchOrdersByDateRange(from, to) : await fetchOrders();
+    return NextResponse.json({ orders });
+  } catch (error) {
+    console.error('Error fetching MercadoLibre orders API:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch orders' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/mercadolibre/questions/route.ts
+++ b/src/app/api/mercadolibre/questions/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getQuestions,
+  getQuestionsByDateRange
+} from '@/features/mercadolibre/utils/questions';
+
+export async function GET(req: NextRequest) {
+  const searchParams = req.nextUrl.searchParams;
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+
+  try {
+    const questions =
+      from && to
+        ? await getQuestionsByDateRange(new Date(from), new Date(to))
+        : await getQuestions();
+    return NextResponse.json({ questions });
+  } catch (error) {
+    console.error('Error fetching MercadoLibre questions API:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch questions' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/mercadolibre/threads/route.ts
+++ b/src/app/api/mercadolibre/threads/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getMessageThreads,
+  getMessageThreadsByDateRange
+} from '@/features/mercadolibre/utils/messages';
+
+export async function GET(req: NextRequest) {
+  const searchParams = req.nextUrl.searchParams;
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+
+  try {
+    const threads =
+      from && to
+        ? await getMessageThreadsByDateRange(new Date(from), new Date(to))
+        : await getMessageThreads();
+    return NextResponse.json({ threads });
+  } catch (error) {
+    console.error('Error fetching MercadoLibre threads API:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch threads' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/mercadolibre-sales/page.tsx
+++ b/src/app/dashboard/mercadolibre-sales/page.tsx
@@ -15,12 +15,7 @@ import { Badge } from '@/components/ui/badge';
 import { EnhancedMercadoLibreOrderList } from '@/features/mercadolibre/components/enhanced-order-list';
 import { MercadoLibreSalesAnalytics } from '@/features/mercadolibre/components/sales-analytics';
 import { DateRangeFilter } from '@/features/mercadolibre/components/date-range-filter';
-import {
-  fetchOrders,
-  fetchOrdersByDateRange,
-  getCurrentMonthRange,
-  type MercadoLibreOrder
-} from '@/lib/mercadolibre';
+import { type MercadoLibreOrder } from '@/lib/mercadolibre';
 import {
   ShoppingCart,
   TrendingUp,
@@ -38,13 +33,19 @@ function SalesContent() {
     loadInitialData();
   }, []);
 
+  const getCurrentMonthLabel = () =>
+    new Date().toLocaleDateString('es-ES', {
+      month: 'long',
+      year: 'numeric'
+    });
+
   const loadInitialData = async () => {
     setIsLoading(true);
     try {
-      const data = await fetchOrders();
-      setOrders(data);
-      const currentMonth = getCurrentMonthRange();
-      setCurrentDateRange(currentMonth.monthName);
+      const res = await fetch('/api/mercadolibre/orders');
+      const json = await res.json();
+      setOrders(json.orders || []);
+      setCurrentDateRange(getCurrentMonthLabel());
     } catch (error) {
       console.error('Error loading orders:', error);
     } finally {
@@ -59,8 +60,14 @@ function SalesContent() {
   ) => {
     setIsLoading(true);
     try {
-      const data = await fetchOrdersByDateRange(fromDate, toDate);
-      setOrders(data);
+      const params = new URLSearchParams();
+      if (fromDate && toDate) {
+        params.set('from', fromDate);
+        params.set('to', toDate);
+      }
+      const res = await fetch(`/api/mercadolibre/orders?${params.toString()}`);
+      const json = await res.json();
+      setOrders(json.orders || []);
       setCurrentDateRange(label || 'Rango personalizado');
     } catch (error) {
       console.error('Error loading orders for date range:', error);

--- a/src/app/dashboard/mercadolibre/messages/page.tsx
+++ b/src/app/dashboard/mercadolibre/messages/page.tsx
@@ -24,8 +24,6 @@ import {
 import { EnhancedMessagesList } from '@/features/mercadolibre/components/enhanced-messages-list';
 import { DateRangeFilter } from '@/features/mercadolibre/components/date-range-filter';
 import {
-  getMessageThreads,
-  getMessageThreadsByDateRange,
   formatMessageDate,
   type MessageThread
 } from '@/features/mercadolibre/utils/messages';
@@ -43,13 +41,14 @@ export default function MessagesPage() {
   const loadMessages = async (fromDate?: Date, toDate?: Date) => {
     setIsLoading(true);
     try {
-      let messageThreads: MessageThread[];
+      const params = new URLSearchParams();
       if (fromDate && toDate) {
-        messageThreads = await getMessageThreadsByDateRange(fromDate, toDate);
-      } else {
-        messageThreads = await getMessageThreads();
+        params.set('from', fromDate.toISOString());
+        params.set('to', toDate.toISOString());
       }
-      setThreads(messageThreads);
+      const res = await fetch(`/api/mercadolibre/threads?${params.toString()}`);
+      const json = await res.json();
+      setThreads(json.threads || []);
     } catch (error) {
       console.error('Error loading messages:', error);
       setThreads([]);

--- a/src/app/dashboard/mercadolibre/questions/page.tsx
+++ b/src/app/dashboard/mercadolibre/questions/page.tsx
@@ -24,8 +24,6 @@ import {
 import { EnhancedQuestionsList } from '@/features/mercadolibre/components/enhanced-questions-list';
 import { DateRangeFilter } from '@/features/mercadolibre/components/date-range-filter';
 import {
-  getQuestions,
-  getQuestionsByDateRange,
   getUnansweredCount,
   getQuestionStatusColor,
   getQuestionStatusText,
@@ -45,13 +43,16 @@ export default function QuestionsPage() {
   const loadQuestions = async (fromDate?: Date, toDate?: Date) => {
     setIsLoading(true);
     try {
-      let questionsData: QuestionWithStatus[];
+      const params = new URLSearchParams();
       if (fromDate && toDate) {
-        questionsData = await getQuestionsByDateRange(fromDate, toDate);
-      } else {
-        questionsData = await getQuestions();
+        params.set('from', fromDate.toISOString());
+        params.set('to', toDate.toISOString());
       }
-      setQuestions(questionsData);
+      const res = await fetch(
+        `/api/mercadolibre/questions?${params.toString()}`
+      );
+      const json = await res.json();
+      setQuestions(json.questions || []);
     } catch (error) {
       console.error('Error loading questions:', error);
       setQuestions([]);


### PR DESCRIPTION
## Summary
- expose server-side MercadoLibre data via `/api/mercadolibre/orders`, `/api/mercadolibre/threads` and `/api/mercadolibre/questions`
- update ML dashboard pages to load data from the new API routes

## Testing
- `pnpm install`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6847680c3f98832b856de70a860acaf3