### PR TITLE
Add ML order tracking dialog

### DIFF
--- a/src/app/api/mercadolibre/tracking/[orderId]/route.ts
+++ b/src/app/api/mercadolibre/tracking/[orderId]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchOrderDetails } from '@/lib/mercadolibre';
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { orderId: string } }
+) {
+  const orderId = params.orderId;
+  if (!orderId) {
+    return NextResponse.json({ error: 'orderId is required' }, { status: 400 });
+  }
+
+  try {
+    const order = await fetchOrderDetails(orderId);
+    if (!order) {
+      return NextResponse.json({ error: 'Order not found' }, { status: 404 });
+    }
+
+    const trackingNumber = order.shipping?.tracking_number;
+    const status = order.shipping?.status || order.status;
+    return NextResponse.json({
+      status,
+      trackingNumber,
+      shipping: order.shipping
+    });
+  } catch (error) {
+    console.error('Error fetching order tracking:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch order tracking' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/features/mercadolibre/components/enhanced-order-list.tsx
+++ b/src/features/mercadolibre/components/enhanced-order-list.tsx
@@ -44,7 +44,8 @@ import {
   Filter,
   ArrowUpDown,
   ChevronLeft,
-  ChevronRight
+  ChevronRight,
+  Package
 } from 'lucide-react';
 import { MercadoLibreOrder } from '@/lib/mercadolibre';
 
@@ -66,6 +67,11 @@ export function EnhancedMercadoLibreOrderList({
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
+  const [trackingInfo, setTrackingInfo] = useState<{
+    orderId: number;
+    status?: string;
+    trackingNumber?: string;
+  } | null>(null);
 
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString('es-CL', {
@@ -156,6 +162,32 @@ export function EnhancedMercadoLibreOrderList({
     window.location.href = `/dashboard/mercadolibre/messages?order=${orderId}`;
   };
 
+  const handleTrackOrder = async (orderId: number) => {
+    try {
+      const res = await fetch(`/api/mercadolibre/tracking/${orderId}`);
+      const data = await res.json();
+      if (res.ok) {
+        setTrackingInfo({ orderId, ...data });
+      } else {
+        setTrackingInfo({ orderId, status: 'No disponible' });
+      }
+    } catch (error) {
+      console.error('Error fetching tracking info:', error);
+      setTrackingInfo({ orderId, status: 'Error' });
+    }
+  };
+
+  const statusMap: Record<string, string> = {
+    handling: 'Preparándose',
+    ready_to_ship: 'Listo para enviar',
+    shipped: 'En camino',
+    delivered: 'Entregado',
+    not_delivered: 'No entregado'
+  };
+
+  const getStatusLabel = (status?: string) =>
+    statusMap[status || ''] || status || 'Desconocido';
+
   const getSortIcon = (field: SortField) => {
     if (sortField !== field)
       return <ArrowUpDown className='h-4 w-4 opacity-50' />;
@@ -163,277 +195,306 @@ export function EnhancedMercadoLibreOrderList({
   };
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className='flex items-center gap-2'>
-          <DollarSign className='h-5 w-5' />
-          Órdenes de MercadoLibre
-        </CardTitle>
-        <CardDescription>
-          Gestiona y consulta todas las órdenes recibidas desde MercadoLibre
-        </CardDescription>
-      </CardHeader>
-      <CardContent className='space-y-4'>
-        {/* Filters and Search */}
-        <div className='flex flex-col gap-4 sm:flex-row'>
-          <div className='relative flex-1'>
-            <Search className='text-muted-foreground absolute top-2.5 left-2 h-4 w-4' />
-            <Input
-              placeholder='Buscar por comprador o ID de orden...'
-              value={searchTerm}
-              onChange={(e) => {
-                setSearchTerm(e.target.value);
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle className='flex items-center gap-2'>
+            <DollarSign className='h-5 w-5' />
+            Órdenes de MercadoLibre
+          </CardTitle>
+          <CardDescription>
+            Gestiona y consulta todas las órdenes recibidas desde MercadoLibre
+          </CardDescription>
+        </CardHeader>
+        <CardContent className='space-y-4'>
+          {/* Filters and Search */}
+          <div className='flex flex-col gap-4 sm:flex-row'>
+            <div className='relative flex-1'>
+              <Search className='text-muted-foreground absolute top-2.5 left-2 h-4 w-4' />
+              <Input
+                placeholder='Buscar por comprador o ID de orden...'
+                value={searchTerm}
+                onChange={(e) => {
+                  setSearchTerm(e.target.value);
+                  setCurrentPage(1);
+                }}
+                className='pl-8'
+              />
+            </div>
+
+            <Select
+              value={`${pageSize}`}
+              onValueChange={(value) => {
+                setPageSize(parseInt(value));
                 setCurrentPage(1);
               }}
-              className='pl-8'
-            />
+            >
+              <SelectTrigger className='w-32'>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value='5'>5 por página</SelectItem>
+                <SelectItem value='10'>10 por página</SelectItem>
+                <SelectItem value='20'>20 por página</SelectItem>
+                <SelectItem value='50'>50 por página</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
 
-          <Select
-            value={`${pageSize}`}
-            onValueChange={(value) => {
-              setPageSize(parseInt(value));
-              setCurrentPage(1);
-            }}
-          >
-            <SelectTrigger className='w-32'>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value='5'>5 por página</SelectItem>
-              <SelectItem value='10'>10 por página</SelectItem>
-              <SelectItem value='20'>20 por página</SelectItem>
-              <SelectItem value='50'>50 por página</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-
-        {/* Stats */}
-        <div className='text-muted-foreground flex gap-4 text-sm'>
-          <span>Total: {filteredAndSortedOrders.length} órdenes</span>
-          <span>•</span>
-          <span>
-            Mostrando {paginatedOrders.length} de{' '}
-            {filteredAndSortedOrders.length}
-          </span>
-        </div>
-
-        {/* Orders Table */}
-        {filteredAndSortedOrders.length === 0 ? (
-          <div className='py-8 text-center'>
-            <p className='text-muted-foreground'>
-              {orders.length === 0
-                ? 'No hay órdenes disponibles'
-                : 'No se encontraron órdenes'}
-            </p>
-            <p className='text-muted-foreground mt-2 text-sm'>
-              {orders.length === 0
-                ? 'Las órdenes aparecerán aquí cuando se configuren las credenciales de MercadoLibre'
-                : 'Intenta con otros términos de búsqueda'}
-            </p>
+          {/* Stats */}
+          <div className='text-muted-foreground flex gap-4 text-sm'>
+            <span>Total: {filteredAndSortedOrders.length} órdenes</span>
+            <span>•</span>
+            <span>
+              Mostrando {paginatedOrders.length} de{' '}
+              {filteredAndSortedOrders.length}
+            </span>
           </div>
-        ) : (
-          <>
-            <div className='rounded-md border'>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Orden ID</TableHead>
-                    <TableHead>
-                      <Button
-                        variant='ghost'
-                        size='sm'
-                        className='h-8 p-0'
-                        onClick={() => handleSort('buyer')}
-                      >
-                        Comprador {getSortIcon('buyer')}
-                      </Button>
-                    </TableHead>
-                    <TableHead>
-                      <Button
-                        variant='ghost'
-                        size='sm'
-                        className='h-8 p-0'
-                        onClick={() => handleSort('date')}
-                      >
-                        Fecha {getSortIcon('date')}
-                      </Button>
-                    </TableHead>
-                    <TableHead>
-                      <Button
-                        variant='ghost'
-                        size='sm'
-                        className='h-8 p-0'
-                        onClick={() => handleSort('amount')}
-                      >
-                        Total {getSortIcon('amount')}
-                      </Button>
-                    </TableHead>
-                    <TableHead>Estado</TableHead>
-                    <TableHead>Acciones</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {paginatedOrders.map((order) => (
-                    <TableRow key={order.id}>
-                      <TableCell className='font-medium'>
-                        <div>
-                          <span className='font-mono'>#{order.id}</span>
-                          {order.pack_id && (
-                            <div className='text-muted-foreground text-xs'>
-                              Pack: {order.pack_id}
-                            </div>
-                          )}
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div className='flex items-center gap-2'>
-                          <User className='text-muted-foreground h-4 w-4' />
-                          {order.buyer.nickname}
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div>
-                          <div className='font-medium'>
-                            {formatDate(order.date_created)}
-                          </div>
-                          <div className='text-muted-foreground text-xs'>
-                            {getTimeAgo(order.date_created)}
-                          </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div className='font-semibold text-green-600'>
-                          {formatCurrency(order.total_amount)}
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <Badge
-                          variant='default'
-                          className='bg-green-100 text-green-800 hover:bg-green-100'
+
+          {/* Orders Table */}
+          {filteredAndSortedOrders.length === 0 ? (
+            <div className='py-8 text-center'>
+              <p className='text-muted-foreground'>
+                {orders.length === 0
+                  ? 'No hay órdenes disponibles'
+                  : 'No se encontraron órdenes'}
+              </p>
+              <p className='text-muted-foreground mt-2 text-sm'>
+                {orders.length === 0
+                  ? 'Las órdenes aparecerán aquí cuando se configuren las credenciales de MercadoLibre'
+                  : 'Intenta con otros términos de búsqueda'}
+              </p>
+            </div>
+          ) : (
+            <>
+              <div className='rounded-md border'>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Orden ID</TableHead>
+                      <TableHead>
+                        <Button
+                          variant='ghost'
+                          size='sm'
+                          className='h-8 p-0'
+                          onClick={() => handleSort('buyer')}
                         >
-                          Pagada
-                        </Badge>
-                      </TableCell>
-                      <TableCell>
-                        <div className='flex items-center gap-2'>
-                          <Dialog>
-                            <DialogTrigger asChild>
-                              <Button
-                                variant='outline'
-                                size='sm'
-                                onClick={() => setSelectedOrder(order)}
-                              >
-                                <Eye className='h-4 w-4' />
-                              </Button>
-                            </DialogTrigger>
-                            <DialogContent className='max-w-2xl'>
-                              <DialogHeader>
-                                <DialogTitle>
-                                  Detalles de la Orden #{order.id}
-                                </DialogTitle>
-                                <DialogDescription>
-                                  Información completa de la orden de
-                                  MercadoLibre
-                                </DialogDescription>
-                              </DialogHeader>
-                              <div className='grid gap-4'>
-                                <div className='grid gap-4 md:grid-cols-2'>
-                                  <div className='space-y-2'>
-                                    <h4 className='flex items-center gap-2 font-semibold'>
-                                      <User className='h-4 w-4' />
-                                      Comprador
-                                    </h4>
-                                    <p className='text-lg'>
-                                      {order.buyer.nickname}
-                                    </p>
-                                  </div>
-                                  <div className='space-y-2'>
-                                    <h4 className='flex items-center gap-2 font-semibold'>
-                                      <Calendar className='h-4 w-4' />
-                                      Fecha de Creación
-                                    </h4>
-                                    <p>{formatDate(order.date_created)}</p>
-                                    <p className='text-muted-foreground text-sm'>
-                                      {getTimeAgo(order.date_created)}
-                                    </p>
-                                  </div>
-                                </div>
-
-                                <div className='space-y-2'>
-                                  <h4 className='flex items-center gap-2 font-semibold'>
-                                    <DollarSign className='h-4 w-4' />
-                                    Total
-                                  </h4>
-                                  <p className='text-2xl font-bold text-green-600'>
-                                    {formatCurrency(order.total_amount)}
-                                  </p>
-                                </div>
-
-                                {order.pack_id && (
-                                  <div className='space-y-2'>
-                                    <h4 className='font-semibold'>Pack ID</h4>
-                                    <p className='bg-muted rounded px-2 py-1 font-mono text-sm'>
-                                      {order.pack_id}
-                                    </p>
-                                  </div>
-                                )}
+                          Comprador {getSortIcon('buyer')}
+                        </Button>
+                      </TableHead>
+                      <TableHead>
+                        <Button
+                          variant='ghost'
+                          size='sm'
+                          className='h-8 p-0'
+                          onClick={() => handleSort('date')}
+                        >
+                          Fecha {getSortIcon('date')}
+                        </Button>
+                      </TableHead>
+                      <TableHead>
+                        <Button
+                          variant='ghost'
+                          size='sm'
+                          className='h-8 p-0'
+                          onClick={() => handleSort('amount')}
+                        >
+                          Total {getSortIcon('amount')}
+                        </Button>
+                      </TableHead>
+                      <TableHead>Estado</TableHead>
+                      <TableHead>Acciones</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {paginatedOrders.map((order) => (
+                      <TableRow key={order.id}>
+                        <TableCell className='font-medium'>
+                          <div>
+                            <span className='font-mono'>#{order.id}</span>
+                            {order.pack_id && (
+                              <div className='text-muted-foreground text-xs'>
+                                Pack: {order.pack_id}
                               </div>
-                            </DialogContent>
-                          </Dialog>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <div className='flex items-center gap-2'>
+                            <User className='text-muted-foreground h-4 w-4' />
+                            {order.buyer.nickname}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <div>
+                            <div className='font-medium'>
+                              {formatDate(order.date_created)}
+                            </div>
+                            <div className='text-muted-foreground text-xs'>
+                              {getTimeAgo(order.date_created)}
+                            </div>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <div className='font-semibold text-green-600'>
+                            {formatCurrency(order.total_amount)}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant='secondary'>
+                            {getStatusLabel(
+                              order.shipping?.status || order.status
+                            )}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          <div className='flex items-center gap-2'>
+                            <Dialog>
+                              <DialogTrigger asChild>
+                                <Button
+                                  variant='outline'
+                                  size='sm'
+                                  onClick={() => setSelectedOrder(order)}
+                                >
+                                  <Eye className='h-4 w-4' />
+                                </Button>
+                              </DialogTrigger>
+                              <DialogContent className='max-w-2xl'>
+                                <DialogHeader>
+                                  <DialogTitle>
+                                    Detalles de la Orden #{order.id}
+                                  </DialogTitle>
+                                  <DialogDescription>
+                                    Información completa de la orden de
+                                    MercadoLibre
+                                  </DialogDescription>
+                                </DialogHeader>
+                                <div className='grid gap-4'>
+                                  <div className='grid gap-4 md:grid-cols-2'>
+                                    <div className='space-y-2'>
+                                      <h4 className='flex items-center gap-2 font-semibold'>
+                                        <User className='h-4 w-4' />
+                                        Comprador
+                                      </h4>
+                                      <p className='text-lg'>
+                                        {order.buyer.nickname}
+                                      </p>
+                                    </div>
+                                    <div className='space-y-2'>
+                                      <h4 className='flex items-center gap-2 font-semibold'>
+                                        <Calendar className='h-4 w-4' />
+                                        Fecha de Creación
+                                      </h4>
+                                      <p>{formatDate(order.date_created)}</p>
+                                      <p className='text-muted-foreground text-sm'>
+                                        {getTimeAgo(order.date_created)}
+                                      </p>
+                                    </div>
+                                  </div>
 
-                          {order.pack_id && (
+                                  <div className='space-y-2'>
+                                    <h4 className='flex items-center gap-2 font-semibold'>
+                                      <DollarSign className='h-4 w-4' />
+                                      Total
+                                    </h4>
+                                    <p className='text-2xl font-bold text-green-600'>
+                                      {formatCurrency(order.total_amount)}
+                                    </p>
+                                  </div>
+
+                                  {order.pack_id && (
+                                    <div className='space-y-2'>
+                                      <h4 className='font-semibold'>Pack ID</h4>
+                                      <p className='bg-muted rounded px-2 py-1 font-mono text-sm'>
+                                        {order.pack_id}
+                                      </p>
+                                    </div>
+                                  )}
+                                </div>
+                              </DialogContent>
+                            </Dialog>
+
                             <Button
                               variant='outline'
                               size='sm'
-                              onClick={() => handleSendMessage(order.id)}
+                              onClick={() => handleTrackOrder(order.id)}
                             >
-                              <MessageSquare className='h-4 w-4' />
+                              <Package className='h-4 w-4' />
                             </Button>
-                          )}
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
 
-            {/* Pagination */}
-            {totalPages > 1 && (
-              <div className='flex items-center justify-between'>
-                <div className='text-muted-foreground text-sm'>
-                  Página {currentPage} de {totalPages}
+                            {order.pack_id && (
+                              <Button
+                                variant='outline'
+                                size='sm'
+                                onClick={() => handleSendMessage(order.id)}
+                              >
+                                <MessageSquare className='h-4 w-4' />
+                              </Button>
+                            )}
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+
+              {/* Pagination */}
+              {totalPages > 1 && (
+                <div className='flex items-center justify-between'>
+                  <div className='text-muted-foreground text-sm'>
+                    Página {currentPage} de {totalPages}
+                  </div>
+                  <div className='flex items-center gap-2'>
+                    <Button
+                      variant='outline'
+                      size='sm'
+                      onClick={() =>
+                        setCurrentPage((prev) => Math.max(1, prev - 1))
+                      }
+                      disabled={currentPage === 1}
+                    >
+                      <ChevronLeft className='h-4 w-4' />
+                      Anterior
+                    </Button>
+                    <Button
+                      variant='outline'
+                      size='sm'
+                      onClick={() =>
+                        setCurrentPage((prev) => Math.min(totalPages, prev + 1))
+                      }
+                      disabled={currentPage === totalPages}
+                    >
+                      Siguiente
+                      <ChevronRight className='h-4 w-4' />
+                    </Button>
+                  </div>
                 </div>
-                <div className='flex items-center gap-2'>
-                  <Button
-                    variant='outline'
-                    size='sm'
-                    onClick={() =>
-                      setCurrentPage((prev) => Math.max(1, prev - 1))
-                    }
-                    disabled={currentPage === 1}
-                  >
-                    <ChevronLeft className='h-4 w-4' />
-                    Anterior
-                  </Button>
-                  <Button
-                    variant='outline'
-                    size='sm'
-                    onClick={() =>
-                      setCurrentPage((prev) => Math.min(totalPages, prev + 1))
-                    }
-                    disabled={currentPage === totalPages}
-                  >
-                    Siguiente
-                    <ChevronRight className='h-4 w-4' />
-                  </Button>
-                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+      {trackingInfo && (
+        <Dialog
+          open={!!trackingInfo}
+          onOpenChange={(o) => !o && setTrackingInfo(null)}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Tracking Orden #{trackingInfo.orderId}</DialogTitle>
+              <DialogDescription>
+                Estado: {getStatusLabel(trackingInfo.status)}
+              </DialogDescription>
+            </DialogHeader>
+            {trackingInfo.trackingNumber && (
+              <div className='flex items-center gap-2'>
+                <span className='font-mono'>{trackingInfo.trackingNumber}</span>
               </div>
             )}
-          </>
-        )}
-      </CardContent>
-    </Card>
+          </DialogContent>
+        </Dialog>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- enhance MercadoLibre order data structure with shipping fields
- add helper to fetch detailed order info
- expose new API route for order tracking
- show shipping status and add tracking button in MercadoLibre orders list

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68476afb0248832b9199afa73ff3da83