### PR TITLE
Add MercadoLibre customers CRM page

### DIFF
--- a/src/app/api/mercadolibre/customers/route.ts
+++ b/src/app/api/mercadolibre/customers/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getCustomers,
+  getCustomersByDateRange
+} from '@/features/mercadolibre/utils/customers';
+
+export async function GET(req: NextRequest) {
+  const searchParams = req.nextUrl.searchParams;
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+  try {
+    const customers =
+      from && to
+        ? await getCustomersByDateRange(new Date(from), new Date(to))
+        : await getCustomers();
+    return NextResponse.json({ customers });
+  } catch (error) {
+    console.error('Error fetching MercadoLibre customers API:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch customers' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/mercadolibre/customers/page.tsx
+++ b/src/app/dashboard/mercadolibre/customers/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import PageContainer from '@/components/layout/page-container';
+import { Heading } from '@/components/ui/heading';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+import { DateRangeFilter } from '@/features/mercadolibre/components/date-range-filter';
+import { EnhancedCustomerList } from '@/features/mercadolibre/components/enhanced-customer-list';
+import type { MercadoLibreCustomer } from '@/features/mercadolibre/utils/customers';
+import { Users, ShoppingCart, DollarSign, Calendar } from 'lucide-react';
+
+export default function CustomersPage() {
+  const [customers, setCustomers] = useState<MercadoLibreCustomer[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [selectedPeriod, setSelectedPeriod] = useState('current-month');
+
+  useEffect(() => {
+    loadCustomers();
+  }, []);
+
+  const loadCustomers = async (from?: string, to?: string) => {
+    setIsLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (from && to) {
+        params.set('from', from);
+        params.set('to', to);
+      }
+      const res = await fetch(
+        `/api/mercadolibre/customers?${params.toString()}`
+      );
+      const json = await res.json();
+      setCustomers(json.customers || []);
+    } catch (error) {
+      console.error('Error loading customers:', error);
+      setCustomers([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleDateRangeChange = (
+    from?: string,
+    to?: string,
+    label?: string
+  ) => {
+    setSelectedPeriod(label || 'custom');
+    loadCustomers(from, to);
+  };
+
+  const totalCustomers = customers.length;
+  const totalOrders = customers.reduce((sum, c) => sum + c.orderCount, 0);
+  const totalSpent = customers.reduce((sum, c) => sum + c.totalSpent, 0);
+
+  return (
+    <PageContainer>
+      <div className='flex-1 space-y-6'>
+        <Heading
+          title='Clientes MercadoLibre'
+          description='Historial y análisis de tus clientes de MercadoLibre'
+        />
+        <DateRangeFilter
+          onDateRangeChange={handleDateRangeChange}
+          isLoading={isLoading}
+        />
+        <div className='flex items-center gap-2'>
+          <Badge variant='outline' className='flex items-center gap-1'>
+            <Calendar className='h-3 w-3' />
+            {selectedPeriod === 'current-month'
+              ? 'Mes actual'
+              : selectedPeriod === 'all-time'
+                ? 'Todo el tiempo'
+                : 'Período personalizado'}
+          </Badge>
+          <Badge variant='secondary'>
+            {totalCustomers} cliente{totalCustomers !== 1 ? 's' : ''}
+          </Badge>
+        </div>
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <Card>
+            <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
+              <CardTitle className='text-sm font-medium'>Clientes</CardTitle>
+              <Users className='text-muted-foreground h-4 w-4' />
+            </CardHeader>
+            <CardContent>
+              <div className='text-2xl font-bold'>{totalCustomers}</div>
+              <p className='text-muted-foreground text-xs'>
+                En el período seleccionado
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
+              <CardTitle className='text-sm font-medium'>Órdenes</CardTitle>
+              <ShoppingCart className='text-muted-foreground h-4 w-4' />
+            </CardHeader>
+            <CardContent>
+              <div className='text-2xl font-bold'>{totalOrders}</div>
+              <p className='text-muted-foreground text-xs'>Total de órdenes</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
+              <CardTitle className='text-sm font-medium'>
+                Total Gastado
+              </CardTitle>
+              <DollarSign className='text-muted-foreground h-4 w-4' />
+            </CardHeader>
+            <CardContent>
+              <div className='text-2xl font-bold'>
+                {new Intl.NumberFormat('es-CL', {
+                  style: 'currency',
+                  currency: 'CLP'
+                }).format(totalSpent)}
+              </div>
+              <p className='text-muted-foreground text-xs'>
+                Entre todos los clientes
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+        <Separator />
+        {isLoading ? (
+          <div className='space-y-6'>Cargando...</div>
+        ) : (
+          <EnhancedCustomerList customers={customers} />
+        )}
+      </div>
+    </PageContainer>
+  );
+}

--- a/src/constants/data.ts
+++ b/src/constants/data.ts
@@ -62,6 +62,14 @@ export const navItems: NavItem[] = [
     items: []
   },
   {
+    title: 'ML Clientes',
+    url: '/dashboard/mercadolibre/customers',
+    icon: 'user2',
+    shortcut: ['c', 'l'],
+    isActive: false,
+    items: []
+  },
+  {
     title: 'Kanban',
     url: '/dashboard/kanban',
     icon: 'kanban',

--- a/src/features/mercadolibre/components/enhanced-customer-list.tsx
+++ b/src/features/mercadolibre/components/enhanced-customer-list.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from '@/components/ui/table';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogTrigger
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select';
+import {
+  ArrowUpDown,
+  User,
+  Search,
+  Eye,
+  ChevronLeft,
+  ChevronRight
+} from 'lucide-react';
+import type { MercadoLibreCustomer } from '../utils/customers';
+
+interface EnhancedCustomerListProps {
+  customers: MercadoLibreCustomer[];
+}
+
+type SortField = 'name' | 'orders' | 'spent';
+type SortOrder = 'asc' | 'desc';
+
+export function EnhancedCustomerList({ customers }: EnhancedCustomerListProps) {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [sortField, setSortField] = useState<SortField>('spent');
+  const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const [selectedCustomer, setSelectedCustomer] =
+    useState<MercadoLibreCustomer | null>(null);
+
+  const formatDate = (dateString: string) =>
+    new Date(dateString).toLocaleDateString('es-CL', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    });
+
+  const formatCurrency = (amount: number) =>
+    new Intl.NumberFormat('es-CL', {
+      style: 'currency',
+      currency: 'CLP'
+    }).format(amount);
+
+  const filtered = useMemo(() => {
+    let data = customers.filter((c) =>
+      c.nickname.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+
+    data.sort((a, b) => {
+      let comp = 0;
+      switch (sortField) {
+        case 'name':
+          comp = a.nickname.localeCompare(b.nickname);
+          break;
+        case 'orders':
+          comp = a.orderCount - b.orderCount;
+          break;
+        case 'spent':
+          comp = a.totalSpent - b.totalSpent;
+          break;
+      }
+      return sortOrder === 'asc' ? comp : -comp;
+    });
+
+    return data;
+  }, [customers, searchTerm, sortField, sortOrder]);
+
+  const totalPages = Math.ceil(filtered.length / pageSize);
+  const paginated = filtered.slice(
+    (currentPage - 1) * pageSize,
+    currentPage * pageSize
+  );
+
+  const toggleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortField(field);
+      setSortOrder('desc');
+    }
+    setCurrentPage(1);
+  };
+
+  const getSortIcon = (field: SortField) => {
+    if (sortField !== field)
+      return <ArrowUpDown className='h-4 w-4 opacity-50' />;
+    return sortOrder === 'asc' ? '↑' : '↓';
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className='flex items-center gap-2'>
+          <User className='h-5 w-5' />
+          Clientes
+        </CardTitle>
+        <CardDescription>Lista de clientes de MercadoLibre</CardDescription>
+      </CardHeader>
+      <CardContent className='space-y-4'>
+        <div className='flex flex-col gap-4 sm:flex-row'>
+          <div className='relative flex-1'>
+            <Search className='text-muted-foreground absolute top-2.5 left-2 h-4 w-4' />
+            <Input
+              placeholder='Buscar por cliente...'
+              value={searchTerm}
+              onChange={(e) => {
+                setSearchTerm(e.target.value);
+                setCurrentPage(1);
+              }}
+              className='pl-8'
+            />
+          </div>
+          <Select
+            value={`${pageSize}`}
+            onValueChange={(value) => {
+              setPageSize(parseInt(value));
+              setCurrentPage(1);
+            }}
+          >
+            <SelectTrigger className='w-32'>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value='5'>5 por página</SelectItem>
+              <SelectItem value='10'>10 por página</SelectItem>
+              <SelectItem value='20'>20 por página</SelectItem>
+              <SelectItem value='50'>50 por página</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className='text-muted-foreground flex gap-4 text-sm'>
+          <span>Total: {filtered.length} clientes</span>
+          <span>•</span>
+          <span>
+            Mostrando {paginated.length} de {filtered.length}
+          </span>
+        </div>
+        {filtered.length === 0 ? (
+          <div className='py-8 text-center'>
+            <p className='text-muted-foreground'>No se encontraron clientes</p>
+          </div>
+        ) : (
+          <>
+            <div className='rounded-md border'>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>
+                      <Button
+                        variant='ghost'
+                        size='sm'
+                        className='h-8 p-0'
+                        onClick={() => toggleSort('name')}
+                      >
+                        Cliente {getSortIcon('name')}
+                      </Button>
+                    </TableHead>
+                    <TableHead>
+                      <Button
+                        variant='ghost'
+                        size='sm'
+                        className='h-8 p-0'
+                        onClick={() => toggleSort('orders')}
+                      >
+                        Órdenes {getSortIcon('orders')}
+                      </Button>
+                    </TableHead>
+                    <TableHead>
+                      <Button
+                        variant='ghost'
+                        size='sm'
+                        className='h-8 p-0'
+                        onClick={() => toggleSort('spent')}
+                      >
+                        Gastado {getSortIcon('spent')}
+                      </Button>
+                    </TableHead>
+                    <TableHead>Última compra</TableHead>
+                    <TableHead>Acciones</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {paginated.map((c) => (
+                    <TableRow key={c.nickname}>
+                      <TableCell className='font-medium'>
+                        {c.nickname}
+                      </TableCell>
+                      <TableCell>{c.orderCount}</TableCell>
+                      <TableCell>{formatCurrency(c.totalSpent)}</TableCell>
+                      <TableCell>{formatDate(c.lastPurchase)}</TableCell>
+                      <TableCell>
+                        <Dialog>
+                          <DialogTrigger asChild>
+                            <Button
+                              variant='outline'
+                              size='sm'
+                              onClick={() => setSelectedCustomer(c)}
+                            >
+                              <Eye className='h-4 w-4' />
+                            </Button>
+                          </DialogTrigger>
+                          <DialogContent className='max-w-xl'>
+                            <DialogHeader>
+                              <DialogTitle>
+                                Compras de {selectedCustomer?.nickname}
+                              </DialogTitle>
+                              <DialogDescription>
+                                Historial de órdenes
+                              </DialogDescription>
+                            </DialogHeader>
+                            <div className='space-y-3'>
+                              {selectedCustomer?.orders.map((o) => (
+                                <div
+                                  key={o.id}
+                                  className='flex items-center justify-between rounded-md border p-2'
+                                >
+                                  <div>
+                                    <span className='font-mono'>#{o.id}</span>
+                                    <div className='text-muted-foreground text-xs'>
+                                      {formatDate(o.date_created)}
+                                    </div>
+                                  </div>
+                                  <div className='font-semibold'>
+                                    {formatCurrency(o.total_amount)}
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </DialogContent>
+                        </Dialog>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+            {totalPages > 1 && (
+              <div className='flex items-center justify-between'>
+                <div className='text-muted-foreground text-sm'>
+                  Página {currentPage} de {totalPages}
+                </div>
+                <div className='flex items-center gap-2'>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                    disabled={currentPage === 1}
+                  >
+                    <ChevronLeft className='h-4 w-4' /> Anterior
+                  </Button>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    onClick={() =>
+                      setCurrentPage((p) => Math.min(totalPages, p + 1))
+                    }
+                    disabled={currentPage === totalPages}
+                  >
+                    Siguiente <ChevronRight className='h-4 w-4' />
+                  </Button>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/mercadolibre/utils/customers.ts
+++ b/src/features/mercadolibre/utils/customers.ts
@@ -1,0 +1,60 @@
+import {
+  fetchOrders,
+  fetchOrdersByDateRange,
+  type MercadoLibreOrder
+} from '@/lib/mercadolibre';
+
+export interface MercadoLibreCustomer {
+  nickname: string;
+  orders: MercadoLibreOrder[];
+  orderCount: number;
+  totalSpent: number;
+  firstPurchase: string;
+  lastPurchase: string;
+}
+
+function aggregateCustomers(
+  orders: MercadoLibreOrder[]
+): MercadoLibreCustomer[] {
+  const map = new Map<string, MercadoLibreCustomer>();
+  for (const order of orders) {
+    const key = order.buyer.nickname || 'Cliente';
+    if (!map.has(key)) {
+      map.set(key, {
+        nickname: key,
+        orders: [],
+        orderCount: 0,
+        totalSpent: 0,
+        firstPurchase: order.date_created,
+        lastPurchase: order.date_created
+      });
+    }
+    const customer = map.get(key)!;
+    customer.orders.push(order);
+    customer.orderCount += 1;
+    customer.totalSpent += order.total_amount;
+    if (new Date(order.date_created) < new Date(customer.firstPurchase)) {
+      customer.firstPurchase = order.date_created;
+    }
+    if (new Date(order.date_created) > new Date(customer.lastPurchase)) {
+      customer.lastPurchase = order.date_created;
+    }
+  }
+
+  return Array.from(map.values()).sort((a, b) => b.totalSpent - a.totalSpent);
+}
+
+export async function getCustomers(): Promise<MercadoLibreCustomer[]> {
+  const orders = await fetchOrders();
+  return aggregateCustomers(orders);
+}
+
+export async function getCustomersByDateRange(
+  from?: Date,
+  to?: Date
+): Promise<MercadoLibreCustomer[]> {
+  const fromStr = from ? from.toISOString() : undefined;
+  const toStr = to ? to.toISOString() : undefined;
+  const orders = await fetchOrdersByDateRange(fromStr, toStr);
+  return aggregateCustomers(orders);
+}


### PR DESCRIPTION
## Summary
- implement customer utilities to aggregate orders by buyer
- expose `/api/mercadolibre/customers` API
- create CRM-style page under `/dashboard/mercadolibre/customers`
- add enhanced customer list component for search and pagination
- link new page from sidebar navigation

## Testing
- `pnpm install`
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_68476eb036d0832bb58a332f2f408a59