### PR TITLE
Fix MercadoLibre messaging

### DIFF
--- a/src/features/mercadolibre/utils/messages.ts
+++ b/src/features/mercadolibre/utils/messages.ts
@@ -96,7 +96,25 @@ export async function sendMessage(
   buyerUserId: string
 ): Promise<boolean> {
   try {
-    return await sendBuyerMessage(packId, text, buyerUserId);
+    const res = await fetch('/api/mercadolibre/send-message', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        packId,
+        buyerId: buyerUserId,
+        message: text
+      })
+    });
+
+    if (!res.ok) {
+      console.error('Failed to send message:', await res.text());
+      return false;
+    }
+
+    const data = await res.json();
+    return !!data.success;
   } catch (error) {
     console.error('Error sending message:', error);
     return false;

--- a/src/features/mercadolibre/utils/questions.ts
+++ b/src/features/mercadolibre/utils/questions.ts
@@ -70,7 +70,21 @@ export async function replyToQuestion(
   answer: string
 ): Promise<boolean> {
   try {
-    return await answerQuestion(questionId, answer);
+    const res = await fetch('/api/mercadolibre/send-message', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ questionId, message: answer })
+    });
+
+    if (!res.ok) {
+      console.error('Failed to reply to question:', await res.text());
+      return false;
+    }
+
+    const data = await res.json();
+    return !!data.success;
   } catch (error) {
     console.error('Error replying to question:', error);
     return false;


### PR DESCRIPTION
## Summary
- fix sendMessage and replyToQuestion utilities to use API calls
- update MercadoLibre messaging API to support packId and auto-fetch buyer id

## Testing
- `npm run lint` *(fails: `next: not found` before installing dependencies, then passes with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68477e8a53a8832bb25658ef32a728f4