### PR TITLE
Improve chat UX with sorting and message status icons

### DIFF
--- a/README_UI_MEJORAS.md
+++ b/README_UI_MEJORAS.md
@@ -74,6 +74,7 @@ src/components/messages/
 - Búsqueda en tiempo real por múltiples campos
 - Filtros combinables
 - Ordenamiento personalizable
+- Conversaciones ordenadas por última actividad
 - Persistencia de estado de filtros
 
 #### **Estados de Conversación**
@@ -102,6 +103,7 @@ src/components/messages/
 - ✅ Diseño moderno y atractivo
 - ✅ Navegación intuitiva
 - ✅ Estados visuales claros
+- ✅ Iconos de estado de mensajes (enviado, entregado, leído)
 - ✅ Feedback de usuario mejorado
 - ✅ Responsivo y accesible
 

--- a/README_UI_MEJORAS.md
+++ b/README_UI_MEJORAS.md
@@ -56,16 +56,20 @@ La UI ha sido completamente rediseñada con una interfaz moderna, intuitiva y fu
 ### 🛠️ Arquitectura de Componentes
 
 #### **Componentes Creados**
-1. **`ConversationFilters`**: Sistema de filtros avanzado
-2. **`ConversationItem`**: Item individual de conversación
-3. **`ChatArea`**: Área completa del chat mejorada
+1. **`ConversationList`**: Vista de conversaciones ordenadas y filtradas
+2. **`ProductCard`**: Muestra detalles del producto vendido
+3. **`ChatHeader`**: Encabezado del chat con información del comprador
+4. **`ChatMessages`**: Lista de mensajes con estados
+5. **`ChatInput`**: Campo de texto y botón para enviar mensajes
 
 #### **Estructura Modular**
 ```
 src/components/messages/
-├── ConversationFilters.tsx
-├── ConversationItem.tsx
-└── ChatArea.tsx
+├── ConversationList.tsx
+├── ProductCard.tsx
+├── ChatHeader.tsx
+├── ChatMessages.tsx
+└── ChatInput.tsx
 ```
 
 ### 📊 Funcionalidades Mejoradas

--- a/src/app/dashboard/mercadolibre/messages/page.tsx
+++ b/src/app/dashboard/mercadolibre/messages/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -18,6 +18,8 @@ import {
   MessageSquare,
   Clock,
   CheckCircle,
+  Check,
+  CheckCheck,
   Truck,
   Hash
 } from 'lucide-react';
@@ -191,13 +193,39 @@ export default function MessagesPage() {
     }
   };
 
-  const filteredPacks = packs.filter(
-    (pack) =>
-      pack.buyer.nickname.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      pack.product_info?.title
-        .toLowerCase()
-        .includes(searchTerm.toLowerCase()) ||
-      pack.id.includes(searchTerm)
+  const getMessageStatusIcon = (status: string) => {
+    switch (status?.toLowerCase()) {
+      case 'read':
+        return <CheckCheck className='ml-1 inline h-3 w-3 text-blue-500' />;
+      case 'delivered':
+      case 'sent':
+        return <Check className='ml-1 inline h-3 w-3 text-gray-400' />;
+      default:
+        return null;
+    }
+  };
+
+  const sortedPacks = useMemo(
+    () =>
+      [...packs].sort(
+        (a, b) =>
+          new Date(b.last_message_date || b.date_created).getTime() -
+          new Date(a.last_message_date || a.date_created).getTime()
+      ),
+    [packs]
+  );
+
+  const filteredPacks = useMemo(
+    () =>
+      sortedPacks.filter(
+        (pack) =>
+          pack.buyer.nickname.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          pack.product_info?.title
+            .toLowerCase()
+            .includes(searchTerm.toLowerCase()) ||
+          pack.id.includes(searchTerm)
+      ),
+    [searchTerm, sortedPacks]
   );
 
   if (loading) {
@@ -417,6 +445,7 @@ export default function MessagesPage() {
                             <span className='ml-2'>
                               {formatTime(message.message_date.received)}
                             </span>
+                            {isFromSeller && getMessageStatusIcon(message.status)}
                           </div>
                         </div>
 

--- a/src/app/dashboard/mercadolibre/messages/page.tsx
+++ b/src/app/dashboard/mercadolibre/messages/page.tsx
@@ -1,28 +1,16 @@
 'use client';
 
 import { useState, useEffect, useRef, useMemo } from 'react';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
-import { Separator } from '@/components/ui/separator';
 import { Card, CardContent } from '@/components/ui/card';
-import {
-  Search,
-  Send,
-  Package,
-  Calendar,
-  DollarSign,
-  User,
-  MessageSquare,
-  Clock,
-  CheckCircle,
-  Check,
-  CheckCheck,
-  Truck,
-  Hash
-} from 'lucide-react';
+import { Search, MessageSquare, Check, CheckCheck } from 'lucide-react';
+
+import ChatHeader from '@/components/messages/ChatHeader';
+import ChatMessages from '@/components/messages/ChatMessages';
+import ChatInput from '@/components/messages/ChatInput';
 
 interface Pack {
   id: string;
@@ -356,153 +344,21 @@ export default function MessagesPage() {
       <div className='flex flex-1 flex-col'>
         {selectedPack ? (
           <>
-            {/* Header del chat */}
-            <div className='border-b border-gray-200 bg-white p-4'>
-              <div className='flex items-center justify-between'>
-                <div className='flex items-center space-x-3'>
-                  <Avatar className='h-10 w-10'>
-                    <AvatarFallback className='bg-blue-500 text-white'>
-                      {selectedPack.buyer.nickname.charAt(0).toUpperCase()}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div>
-                    <h2 className='font-semibold text-gray-900'>
-                      {selectedPack.buyer.nickname}
-                    </h2>
-                    <p className='text-sm text-gray-500'>
-                      Orden #{selectedPack.order_id || selectedPack.id}
-                    </p>
-                  </div>
-                </div>
-
-                {selectedPack.product_info && (
-                  <div className='flex items-center space-x-2 text-sm text-gray-600'>
-                    <Package className='h-4 w-4' />
-                    <span className='max-w-xs truncate'>
-                      {selectedPack.product_info.title}
-                    </span>
-                    <span className='font-semibold text-green-600'>
-                      {formatPrice(
-                        selectedPack.total_amount,
-                        selectedPack.currency_id
-                      )}
-                    </span>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* Área de mensajes */}
-            <ScrollArea className='flex-1 p-4'>
-              {messagesLoading ? (
-                <div className='flex h-full items-center justify-center'>
-                  <div className='text-center'>
-                    <div className='mx-auto mb-2 h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600'></div>
-                    <p className='text-gray-600'>Cargando mensajes...</p>
-                  </div>
-                </div>
-              ) : messages.length === 0 ? (
-                <div className='flex h-full items-center justify-center'>
-                  <div className='text-center text-gray-500'>
-                    <MessageSquare className='mx-auto mb-2 h-12 w-12 opacity-50' />
-                    <p>No hay mensajes en esta conversación</p>
-                  </div>
-                </div>
-              ) : (
-                <div className='space-y-4'>
-                  {messages.map((message, index) => {
-                    const isFromSeller =
-                      message.from.user_id ===
-                      selectedPack.seller.id.toString();
-
-                    return (
-                      <div
-                        key={`${message.message_id.value}-${index}`}
-                        className={`flex ${isFromSeller ? 'justify-end' : 'justify-start'}`}
-                      >
-                        <div
-                          className={`max-w-xs lg:max-w-md ${isFromSeller ? 'order-2' : 'order-1'}`}
-                        >
-                          <div
-                            className={`rounded-lg px-4 py-2 ${
-                              isFromSeller
-                                ? 'bg-blue-500 text-white'
-                                : 'bg-gray-200 text-gray-900'
-                            }`}
-                          >
-                            <p className='text-sm'>{message.text}</p>
-                          </div>
-                          <div
-                            className={`mt-1 text-xs text-gray-500 ${
-                              isFromSeller ? 'text-right' : 'text-left'
-                            }`}
-                          >
-                            <span>
-                              {isFromSeller
-                                ? 'Tú'
-                                : selectedPack.buyer.nickname}
-                            </span>
-                            <span className='ml-2'>
-                              {formatTime(message.message_date.received)}
-                            </span>
-                            {isFromSeller && getMessageStatusIcon(message.status)}
-                          </div>
-                        </div>
-
-                        <Avatar
-                          className={`h-8 w-8 ${isFromSeller ? 'order-1 mr-2' : 'order-2 ml-2'}`}
-                        >
-                          <AvatarFallback
-                            className={
-                              isFromSeller
-                                ? 'bg-blue-500 text-white'
-                                : 'bg-gray-400 text-white'
-                            }
-                          >
-                            {isFromSeller
-                              ? 'T'
-                              : selectedPack.buyer.nickname
-                                  .charAt(0)
-                                  .toUpperCase()}
-                          </AvatarFallback>
-                        </Avatar>
-                      </div>
-                    );
-                  })}
-                  <div ref={messagesEndRef} />
-                </div>
-              )}
-            </ScrollArea>
-
-            {/* Input para escribir mensaje */}
-            <div className='border-t border-gray-200 bg-white p-4'>
-              <div className='flex space-x-2'>
-                <Input
-                  placeholder='Escribe un mensaje...'
-                  value={newMessage}
-                  onChange={(e) => setNewMessage(e.target.value)}
-                  onKeyPress={(e) => {
-                    if (e.key === 'Enter' && !e.shiftKey) {
-                      e.preventDefault();
-                      sendMessage();
-                    }
-                  }}
-                  disabled={sendingMessage}
-                  className='flex-1'
-                />
-                <Button
-                  onClick={sendMessage}
-                  disabled={!newMessage.trim() || sendingMessage}
-                  className='bg-blue-500 hover:bg-blue-600'
-                >
-                  {sendingMessage ? (
-                    <div className='h-4 w-4 animate-spin rounded-full border-b-2 border-white'></div>
-                  ) : (
-                    <Send className='h-4 w-4' />
-                  )}
-                </Button>
-              </div>
-            </div>
+            <ChatHeader pack={selectedPack} formatPrice={formatPrice} />
+            <ChatMessages
+              pack={selectedPack}
+              messages={messages}
+              messagesEndRef={messagesEndRef}
+              formatTime={formatTime}
+              getMessageStatusIcon={getMessageStatusIcon}
+              loading={messagesLoading}
+            />
+            <ChatInput
+              value={newMessage}
+              onChange={setNewMessage}
+              onSend={sendMessage}
+              sending={sendingMessage}
+            />
           </>
         ) : (
           /* Estado sin conversación seleccionada */

--- a/src/components/messages/ChatHeader.tsx
+++ b/src/components/messages/ChatHeader.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Package } from 'lucide-react';
+
+interface Pack {
+  id: string;
+  order_id?: string;
+  buyer: {
+    nickname: string;
+  };
+  seller: {
+    nickname: string;
+  };
+  currency_id: string;
+  total_amount: number;
+  product_info?: {
+    title: string;
+  };
+}
+
+interface ChatHeaderProps {
+  pack: Pack;
+  formatPrice: (amount: number, currency: string) => string;
+}
+
+export default function ChatHeader({ pack, formatPrice }: ChatHeaderProps) {
+  return (
+    <div className='border-b border-gray-200 bg-white p-4'>
+      <div className='flex items-center justify-between'>
+        <div className='flex items-center space-x-3'>
+          <Avatar className='h-10 w-10'>
+            <AvatarFallback className='bg-blue-500 text-white'>
+              {pack.buyer.nickname.charAt(0).toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+          <div>
+            <h2 className='font-semibold text-gray-900'>{pack.buyer.nickname}</h2>
+            <p className='text-sm text-gray-500'>
+              Orden #{pack.order_id || pack.id}
+            </p>
+          </div>
+        </div>
+
+        {pack.product_info && (
+          <div className='flex items-center space-x-2 text-sm text-gray-600'>
+            <Package className='h-4 w-4' />
+            <span className='max-w-xs truncate'>{pack.product_info.title}</span>
+            <span className='font-semibold text-green-600'>
+              {formatPrice(pack.total_amount, pack.currency_id)}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/messages/ChatInput.tsx
+++ b/src/components/messages/ChatInput.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Send } from 'lucide-react';
+
+interface ChatInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSend: () => void;
+  sending: boolean;
+}
+
+export default function ChatInput({ value, onChange, onSend, sending }: ChatInputProps) {
+  return (
+    <div className='border-t border-gray-200 bg-white p-4'>
+      <div className='flex space-x-2'>
+        <Input
+          placeholder='Escribe un mensaje...'
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyPress={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              onSend();
+            }
+          }}
+          disabled={sending}
+          className='flex-1'
+        />
+        <Button onClick={onSend} disabled={!value.trim() || sending} className='bg-blue-500 hover:bg-blue-600'>
+          {sending ? (
+            <div className='h-4 w-4 animate-spin rounded-full border-b-2 border-white'></div>
+          ) : (
+            <Send className='h-4 w-4' />
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/messages/ChatMessages.tsx
+++ b/src/components/messages/ChatMessages.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { MessageSquare } from 'lucide-react';
+import { ReactNode, RefObject } from 'react';
+
+interface Pack {
+  seller: { id: number; nickname: string };
+  buyer: { nickname: string };
+}
+
+interface ApiMessage {
+  message_id: { value: string };
+  message_date: { received: string };
+  from: { user_id: string };
+  to: { user_id: string };
+  text: string;
+  status: string;
+}
+
+interface ChatMessagesProps {
+  pack: Pack;
+  messages: ApiMessage[];
+  messagesEndRef: RefObject<HTMLDivElement>;
+  formatTime: (dateString: string) => string;
+  getMessageStatusIcon: (status: string) => ReactNode;
+  loading: boolean;
+}
+
+export default function ChatMessages({
+  pack,
+  messages,
+  messagesEndRef,
+  formatTime,
+  getMessageStatusIcon,
+  loading
+}: ChatMessagesProps) {
+  if (loading) {
+    return (
+      <div className='flex h-full items-center justify-center'>
+        <div className='text-center'>
+          <div className='mx-auto mb-2 h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600'></div>
+          <p className='text-gray-600'>Cargando mensajes...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (messages.length === 0) {
+    return (
+      <div className='flex h-full items-center justify-center'>
+        <div className='text-center text-gray-500'>
+          <MessageSquare className='mx-auto mb-2 h-12 w-12 opacity-50' />
+          <p>No hay mensajes en esta conversación</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea className='flex-1 p-4'>
+      <div className='space-y-4'>
+        {messages.map((message, index) => {
+          const isFromSeller = message.from.user_id === pack.seller.id.toString();
+          return (
+            <div
+              key={`${message.message_id.value}-${index}`}
+              className={`flex ${isFromSeller ? 'justify-end' : 'justify-start'}`}
+            >
+              <div className={`max-w-xs lg:max-w-md ${isFromSeller ? 'order-2' : 'order-1'}`}>
+                <div className={`rounded-lg px-4 py-2 ${isFromSeller ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-900'}`}>
+                  <p className='text-sm'>{message.text}</p>
+                </div>
+                <div className={`mt-1 text-xs text-gray-500 ${isFromSeller ? 'text-right' : 'text-left'}`}>
+                  <span>{isFromSeller ? 'Tú' : pack.buyer.nickname}</span>
+                  <span className='ml-2'>{formatTime(message.message_date.received)}</span>
+                  {isFromSeller && getMessageStatusIcon(message.status)}
+                </div>
+              </div>
+
+              <Avatar className={`h-8 w-8 ${isFromSeller ? 'order-1 mr-2' : 'order-2 ml-2'}`}>
+                <AvatarFallback className={isFromSeller ? 'bg-blue-500 text-white' : 'bg-gray-400 text-white'}>
+                  {isFromSeller ? 'T' : pack.buyer.nickname.charAt(0).toUpperCase()}
+                </AvatarFallback>
+              </Avatar>
+            </div>
+          );
+        })}
+        <div ref={messagesEndRef} />
+      </div>
+    </ScrollArea>
+  );
+}

--- a/src/components/messages/ConversationList.tsx
+++ b/src/components/messages/ConversationList.tsx
@@ -77,6 +77,28 @@ export default function ConversationList({
   searchTerm,
   onSearchChange
 }: ConversationListProps) {
+  const sortedPacks = useMemo(
+    () =>
+      [...packs].sort(
+        (a, b) =>
+          new Date(b.last_message_date || b.date_created).getTime() -
+          new Date(a.last_message_date || a.date_created).getTime()
+      ),
+    [packs]
+  );
+
+  const filteredPacks = useMemo(
+    () =>
+      sortedPacks.filter(
+        (pack) =>
+          pack.buyer.nickname.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          pack.product_info?.title
+            .toLowerCase()
+            .includes(searchTerm.toLowerCase()) ||
+          pack.id.includes(searchTerm)
+      ),
+    [searchTerm, sortedPacks]
+  );
   const formatRelativeTime = (dateString: string) => {
     const now = new Date();
     const date = new Date(dateString);
@@ -164,7 +186,7 @@ export default function ConversationList({
     );
   }
 
-  if (packs.length === 0) {
+  if (filteredPacks.length === 0) {
     return (
       <div className='flex h-64 flex-col items-center justify-center text-gray-400'>
         <Users className='mb-4 h-16 w-16 opacity-50' />
@@ -193,7 +215,7 @@ export default function ConversationList({
   return (
     <ScrollArea className='flex-1'>
       <div className='space-y-1 p-2'>
-        {packs.map((pack, index) => (
+        {filteredPacks.map((pack, index) => (
           <div
             key={`${pack.id}-${index}`}
             className={`group relative cursor-pointer rounded-xl p-3 transition-all duration-200 ${


### PR DESCRIPTION
## Summary
- sort conversation list by recent activity
- filter sorted conversations by search term
- show message status icons for sent, delivered and read
- document new improvements in UI guide

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c9106258832b91a56cb25f75d15a